### PR TITLE
Add package website link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     gridExtra,
     pheatmap
 VignetteBuilder: knitr
-URL: https://github.com/FridleyLab/spatialTIME
+URL: https://fridleylab.github.io/spatialTIME/, https://github.com/FridleyLab/spatialTIME
 BugReports: https://github.com/FridleyLab/spatialTIME/issues
 NeedsCompilation: no
 Packaged: 2021-08-19 22:31:18 UTC; 4468179


### PR DESCRIPTION
You may consider adding it in the About page

Also, if you want automatic deployment, you can set this up with `usethis::use_pkgdown_github_pages()`.

![image](https://github.com/FridleyLab/spatialTIME/assets/52606734/0a010a77-6c30-4724-9b82-f97ca3293a0b)
