### PR TITLE
Update due to spatstat functions moved to spatstat.univar.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     scales,
     grDevices,
     purrr,
+    spatstat.univar,
     spatstat.geom,
     spatstat.explore,
     RColorBrewer,

--- a/R/bi_nn_g2.R
+++ b/R/bi_nn_g2.R
@@ -166,9 +166,9 @@ bi_NN_G = function(mif,
       } else if(edge_correction == "rs"){
         #for edge correction rs
         o <- pmin.int(obs_nnd, obs_bdry)
-        result = spatstat.explore::km.rs(o, obs_bdry, obs_d,
-                                         spatstat.geom::handle.r.b.args(r_range, NULL, W, 
-                                                                        rmaxdefault = spatstat.explore::rmax.rule("G", win, lamJ)))
+        result = spatstat.univar::km.rs(o, obs_bdry, obs_d,
+                                        spatstat.geom::handle.r.b.args(r_range, NULL, W, 
+                                                                       rmaxdefault = spatstat.explore::rmax.rule("G", win, lamJ)))
         G_cross_df = cbind(G_cross_df, `Observed G` = result$rs)
         #permutations
         G_cross_df2 = lapply(seq(1:num_permutations), function(perm_num){
@@ -181,9 +181,9 @@ bi_NN_G = function(mif,
                                                                     window = win))
           obs_d = (obs_nnd <= obs_bdry)
           o <- pmin.int(obs_nnd, obs_bdry)
-          result = spatstat.explore::km.rs(o, obs_bdry, obs_d,
-                                           spatstat.geom::handle.r.b.args(r_range, NULL, W, 
-                                                                          rmaxdefault = spatstat.explore::rmax.rule("G", win, lamJ)))
+          result = spatstat.univar::km.rs(o, obs_bdry, obs_d,
+                                          spatstat.geom::handle.r.b.args(r_range, NULL, W, 
+                                                                         rmaxdefault = spatstat.explore::rmax.rule("G", win, lamJ)))
           
           data.frame(r = r_range,
                      `Permuted G` = result$rs,

--- a/R/ripleys_k.R
+++ b/R/ripleys_k.R
@@ -276,7 +276,7 @@ ripleys_k = function(mif,
               dists[dists == 0 | dists > max(r_range)] = NA
             
               if(edge_correction == "none"){
-                counts = cumsum(spatstat.geom::whist(dists, 
+                counts = cumsum(spatstat.univar::whist(dists, 
                                                      spatstat.geom::handle.r.b.args(r_range, breaks=NULL, win, rmaxdefault = max(r_range))$val))
               } else {            
                 

--- a/R/utils-helpers.R
+++ b/R/utils-helpers.R
@@ -749,7 +749,7 @@ calculateK = function(i_dat, j_dat, anchor, counted, area, win, big, r_range, ed
           return(counts)
         }
         if(edge_correction %in% c("none")){
-          counts = cumsum(spatstat.geom::whist(spatstat.geom::crosspairs(i_tmp, j_tmp, max(r_range), what = "ijd")$d,
+          counts = cumsum(spatstat.univar::whist(spatstat.geom::crosspairs(i_tmp, j_tmp, max(r_range), what = "ijd")$d,
                                                spatstat.geom::handle.r.b.args(r_range, breaks=NULL, win, rmaxdefault = max(r_range))$val))
           return(counts)
         }


### PR DESCRIPTION
Some functions from `spatstat.geom` and `spatstat.explore` have been moved to `spatstat.univar`. Please submit a new version of your package to CRAN as soon as possible so we can finalize the move of these functions. Thank you for your cooperation.